### PR TITLE
validate the file type to only load js file as config

### DIFF
--- a/lib/proxyRoute.js
+++ b/lib/proxyRoute.js
@@ -55,7 +55,12 @@ var loadConfig = function(path,defConfig, callback) {
             return;
         }
         _.forEach(files, function(val) {
-            var m = require((path + p.sep + val).replace('.js', ''));
+            // 判断文件类型是否为js
+            var m = /\.js$/.test(path + p.sep + val) ? require((path + p.sep + val).replace('.js', '')) : null;
+
+            // 文件不是js， 则退出
+            if (m === null) return;
+
             if (m.domain && m.res && _.isArray(m.res) && m.res.length > 0) {
                 _.forEach(m.res, function(v) {
                     v.domain = m.domain;


### PR DESCRIPTION
It is better to validate the file type when loading proxy router config.
